### PR TITLE
Passing exceptions through the callback for better handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 ## Booru-Getter
-###A Node.js module for retrieving search information or image urls from Safebooru and Gelbooru
+##A Node.js module for retrieving search information or image urls from Safebooru and Gelbooru
 
-###Usage
+##Usage
 
-####Safebooru
+###Safebooru
 [A worksafe booru.](https://safebooru.org/) 
 
-```
+```js
 const getter = require('booru-getter')
 
 //Searching by tags
@@ -15,22 +15,32 @@ getter.get(1, 0, "brown_hair+-red*", (xml) =>{
 }
 
 //Retrieving a random image with matching tags
-getter.getRandom("brown_hair+red_shirt+-dress*", (url)=>{
+getter.getRandom("blue_hair+red_shirt+-dress*", (err, url)=>{
+   
+   if(err){
+        //handle error
+    }
+    
 	//do something with URL here
 }
 ```
 
-####Gelbooru
+###Gelbooru
 [A booru that contains NSFW images.](http://gelbooru.com/)
 
-```
+```js
 //Searching by tags
 getter.getLewd(1, 0, "brown_hair+-red*", (xml) =>{
 	//work with XML here.
 }
 
 //Retrieving a random image with matching tags
-getter.getRandomLewd("brown_hair+red_shirt+-dress*", (url)=>{
+getter.getRandomLewd("blue_hair+red_shirt+-dress*", (err,url)=>{
+
+    if(err){
+        //handle error
+    }
+    
 	//do something with URL here
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-## Booru-Getter
-##A Node.js module for retrieving search information or image urls from Safebooru and Gelbooru
+# Booru-Getter
+### A Node.js module for retrieving search information or image urls from Safebooru and Gelbooru
 
-##Usage
+### Usage
 
-###Safebooru
+##### Safebooru
 [A worksafe booru.](https://safebooru.org/) 
 
 ```js
@@ -25,7 +25,7 @@ getter.getRandom("blue_hair+red_shirt+-dress*", (err, url)=>{
 }
 ```
 
-###Gelbooru
+#### Gelbooru
 [A booru that contains NSFW images.](http://gelbooru.com/)
 
 ```js

--- a/index.js
+++ b/index.js
@@ -54,9 +54,13 @@ exports.getRandom = function(tags, callback){
 							console.log("Error", err);
 						else {
 							console.log(result.posts);
-							var output = result.posts.post[0].$.file_url;//.replace("//","");
+                            try{
+                                var output = result.posts.post[0].$.file_url;//.replace("//","");
+							callback(undefined,"http:"+output);	
 							// callback("http://"+output);	
-							callback("http:"+output);	
+                            }catch(err){
+                                callback(err,undefined)
+                            }
 						}
 					});
 				});		
@@ -87,9 +91,14 @@ exports.getRandomLewd = function(tags, callback)
 							console.log("Error", err);
 						else {
 							console.log(result.posts);
+                             try{
+                                
 							var output = result.posts.post[0].$.file_url;//.replace("//","");
 							// callback("http://"+output);	
-							callback(output);//.replace("http:", "http://"));	
+							callback(undefined,output);//.replace("http:", "http://"));	
+                                }catch(err){
+                                    callback(err,undefined)
+                                }
 						}
 					});
 				});		


### PR DESCRIPTION
If for any reason the URL response comes messed up, there's no way to work around the error because the module simply stops. Passing the exception as an err argument makes easier to handle exceptions without the need of wrap the entire call in a try/catch block.